### PR TITLE
Configure ServiceProvider before Configure(IAppBuilder)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+[*.cs]
+dotnet_sort_system_directives_first = false
+
+csharp_new_line_before_open_brace = none
+

--- a/Extensions/ServiceProviderExtensions.cs
+++ b/Extensions/ServiceProviderExtensions.cs
@@ -9,6 +9,9 @@ namespace Arex388.AspNet.Mvc.Startup {
         public static IServiceCollection AddControllers(
             this IServiceCollection services,
             Assembly assembly) {
+
+            ServiceProviderDependencyResolver.EnsureConfigured();
+
             var type = typeof(IController);
 
             var controllers = assembly.GetExportedTypes().Where(

--- a/ServiceProviderDependencyResolver.cs
+++ b/ServiceProviderDependencyResolver.cs
@@ -28,5 +28,16 @@ namespace Arex388.AspNet.Mvc.Startup {
 
             return scope.ServiceProvider.GetServices(serviceType);
         }
+
+        internal static void EnsureConfigured() {
+            if (DependencyResolver.Current is ServiceProviderDependencyResolver) {
+                return;
+            }
+
+            var resolver = new ServiceProviderDependencyResolver();
+
+            DependencyResolver.SetResolver(resolver);
+        }
+
     }
 }

--- a/ServiceScopeModule.cs
+++ b/ServiceScopeModule.cs
@@ -1,14 +1,9 @@
-﻿using Microsoft.Extensions.DependencyInjection;
-using System;
+﻿using System;
 using System.Web;
 
 namespace Arex388.AspNet.Mvc.Startup {
     internal sealed class ServiceScopeModule :
         IHttpModule {
-        private static ServiceProvider _serviceProvider;
-
-        public static void SetServiceProvider(
-            ServiceProvider serviceProvider) => _serviceProvider = serviceProvider;
 
         #region IHttpModule
         public void Dispose() {
@@ -26,7 +21,7 @@ namespace Arex388.AspNet.Mvc.Startup {
             EventArgs e) {
             var context = sender.ToHttpContext();
 
-            context.Items[Constants.ServiceScopeType] = _serviceProvider.CreateScope();
+            StartupApplication.CreateScope(context);
         }
 
         private static void OnContextEndRequest(
@@ -34,9 +29,7 @@ namespace Arex388.AspNet.Mvc.Startup {
             EventArgs e) {
             var context = sender.ToHttpContext();
 
-            if (context.Items[Constants.ServiceScopeType] is IServiceScope scope) {
-                scope.Dispose();
-            }
+            StartupApplication.DisposeScope(context);
         }
     }
 }

--- a/StartupApplication.cs
+++ b/StartupApplication.cs
@@ -5,7 +5,7 @@ using System;
 using System.Web;
 using System.Web.Mvc;
 
-[assembly: PreApplicationStartMethod(typeof(StartupApplication), "InitModule")]
+[assembly: PreApplicationStartMethod(typeof(StartupApplication), nameof(StartupApplication.InitModule))]
 namespace Arex388.AspNet.Mvc.Startup {
     public abstract class StartupApplication :
         HttpApplication {

--- a/StartupApplication.cs
+++ b/StartupApplication.cs
@@ -13,13 +13,24 @@ namespace Arex388.AspNet.Mvc.Startup {
 
         public static IServiceProvider ServiceProvider { get; private set; }
 
-        public void Configuration(
-            IAppBuilder app) => Configure(app);
+        public void Configuration(IAppBuilder app) {
+            BuildServiceProvider();
+            Configure(app);
+        }
 
         public abstract void Configure(
             IAppBuilder app);
 
+        [Obsolete("ServiceProvider is now configured before Configure().")]
         public void ConfigureServices() {
+            BuildServiceProvider();
+        }
+
+        protected virtual void BuildServiceProvider() {
+            if (ServiceProvider != null) {
+                return;
+            }
+
             var services = new ServiceCollection();
 
             ConfigureServices(services);

--- a/StartupApplication.cs
+++ b/StartupApplication.cs
@@ -3,7 +3,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Owin;
 using System;
 using System.Web;
-using System.Web.Mvc;
 
 [assembly: PreApplicationStartMethod(typeof(StartupApplication), nameof(StartupApplication.InitModule))]
 namespace Arex388.AspNet.Mvc.Startup {
@@ -38,10 +37,6 @@ namespace Arex388.AspNet.Mvc.Startup {
             var provider = services.BuildServiceProvider();
 
             ServiceProvider = provider;
-
-            var resolver = new ServiceProviderDependencyResolver();
-
-            DependencyResolver.SetResolver(resolver);
         }
 
         public abstract void ConfigureServices(


### PR DESCRIPTION
I've finally started using this in the project I mentioned in #1, and ran into an issue wiring up [Hangfire.NetCore](https://www.nuget.org/packages/Hangfire.NetCore) to use DI for job activation. Specifically, `services.AddHangfire(...)` doesn't execute custom configuration until an [`IGlobalConfiguration` is resolved](https://github.com/HangfireIO/Hangfire/blob/c23b01061860b4f5b5692e23e8f8cbdbe4681a8b/src/Hangfire.AspNetCore/HangfireServiceCollectionExtensions.cs#L76-L100). This is [verified for full ASP.NET Core](https://github.com/HangfireIO/Hangfire/blob/c23b01061860b4f5b5692e23e8f8cbdbe4681a8b/src/Hangfire.AspNetCore/HangfireApplicationBuilderExtensions.cs#L45), but I had to figure that out the hard way.

Anyway, to fix this I needed access to the `IServiceProvider`, which wasn't exposed anywhere. To that end, this PR includes two important changes:
1. The `IServiceProvider` and methods to work with it have moved from `private` in `ServiceScopeModule` to `public` in `StartupApplication`
2. The `IServiceProvider` is now automatically built before `Configure(IAppBuilder)`, as also happens in the ASP.NET Core hosting lifecycle.
    - I've marked `ConfigureServices()` as `[Obsolete]`.

I also included a few bonus changes, including:
1. Added `.editorconfig` to enforce non-VS-default code standards (K&R braces, `using` order)
2. Wiring up the MVC `DependencyResolver` now happens in `AddControllers()`, as the resolver is useless if the controllers haven't been registered.

---------------------------

For reference, this is an abbreviated version of what my `Hangfire.NetCore` config now looks like:

```csharp
        public override void Configure(IAppBuilder app)
        {
            // Force initialization before we start server
            ServiceProvider.GetRequiredService<IGlobalConfiguration>();

            app.UseHangfireDashboard();

            app.UseHangfireServer(new BackgroundJobServerOptions
            {
                // Uses AspNetCoreJobActivator registered by services.AddHangfire()
                Activator = ServiceProvider.GetService<JobActivator>(),
            });
        }

        public override void ConfigureServices(IServiceCollection services)
        {
            services.AddHangfire(config => { /* ... */ })
        }
```