### PR TITLE
Add MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) @arex388 and Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Following on from https://github.com/arex388/Arex388.AspNet.Mvc.Startup/issues/1#issuecomment-712883024 …

> > As for the licensing, I never really understood what license to pick so I just left it blank.
> 
> I'm not a lawyer, let alone your lawyer, so don't consider this legal advice, but https://choosealicense.com/ does a good job of describing your options. I personally [use MIT](https://github.com/dahlbyk/posh-git/blob/master/LICENSE.txt), as does [.NET Core](https://github.com/dotnet/runtime/blob/main/LICENSE.TXT); [ASP.NET uses Apache](https://github.com/aspnet/AspNetWebStack/blob/main/LICENSE.txt). A reciprocal license like GPL might discourage folks from using the project.

You have permission to use my contributions; I'd like permission to use yours. 😀 